### PR TITLE
fix: support device plugin daemonset for higher k8s version

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -22,6 +22,6 @@ echo "Building Cambricon device plugin docker image."
 docker build -t  cambricon-k8s-device-plugin:v1.0.0  -f Dockerfile  .
 
 echo "Saving Cambricon device plugin docker image."
-docker save -o "$curpath/image/cambricon_device_plugin_ubuntu.tar cambricon-k8s-device-plugin:v1.0.0"
+docker save -o $curpath/image/cambricon_device_plugin_ubuntu.tar cambricon-k8s-device-plugin:v1.0.0
 
 rm -rf "$curpath/libcndev.so"

--- a/cambricon-device-plugin.yml
+++ b/cambricon-device-plugin.yml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cambricon-device-plugin-daemonset
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: cambricon-device-plugin-ds
   template:
     metadata:
       # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler


### PR DESCRIPTION
close: https://github.com/Cambricon/cambricon-k8s-device-plugin/issues/6

 support k8s version > 1.14 and fix docker save bug
