### PR TITLE
fix: correct typo in DsmluResourceAssigned constant 

### DIFF
--- a/device-plugin/pkg/mlu/const.go
+++ b/device-plugin/pkg/mlu/const.go
@@ -24,7 +24,7 @@ const (
 	DsmluLockTime           = "cambricon.com/dsmlu.lock"
 	DsmluProfile            = "CAMBRICON_DSMLU_PROFILE"
 	DsmluProfileAndInstance = "CAMBRICON_DSMLU_PROFILE_INSTANCE"
-	DsmluResourceAssigned   = "CAMBRICON_DSMLU_ASSIGHED"
+	DsmluResourceAssigned   = "CAMBRICON_DSMLU_ASSIGNED"
 
 	normalMlu      = "mlu"
 	realCounts     = "real-mlu-counts"


### PR DESCRIPTION
`CAMBRICON_DSMLU_ASSIGHED` should be `CAMBRICON_DSMLU_ASSIGNED`